### PR TITLE
Update Multipart.scala

### DIFF
--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -196,7 +196,7 @@ object Multipart {
   private[play] object PartInfoMatcher {
     def unapply(headers: Map[String, String]): Option[String] = {
 
-      val KeyValue = """^([a-zA-Z_0-9]+)="(.*)"$""".r
+      val KeyValue = """^([a-zA-Z_0-9]+)="?(.*)"?$""".r
 
       for {
         values <- headers.get("content-disposition").map(


### PR DESCRIPTION
## Fixes
Made regex for PartInfoMatcher and FileInfoMatcher the same.
Multipart form data parts have optional quotes. This was already fixed for "filename" param, but not for regular parameters. 

## References
I've also commented on this issue:
https://github.com/playframework/playframework/issues/6275

